### PR TITLE
fix: Improve support for darkmode

### DIFF
--- a/client/components/styles/app.scss
+++ b/client/components/styles/app.scss
@@ -2,6 +2,7 @@ $border-color: #cdcdcd;
 
 #root {
   height: 100%;
+  background: white;
 }
 
 .hide {


### PR DESCRIPTION
This PR doesn't add a darkmode theme, but improves the usability of the extension a lot when chrome is in darkmode.

![before-and-after](https://user-images.githubusercontent.com/207248/99537324-ce2af400-29ab-11eb-88c2-852ea5038f25.png)
